### PR TITLE
Add Build and Lint  workflows

### DIFF
--- a/.github/workflows/update-lint-and-build.yml
+++ b/.github/workflows/update-lint-and-build.yml
@@ -1,0 +1,55 @@
+name: Build and Lint Workflow
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  push:
+    branches:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    continue-on-error: true
+    steps:
+      - uses: actions/setup-python@master
+        with:
+          python-version: 3
+      - run: pip install sphinx-lint
+      - uses: actions/checkout@master
+        with:
+          ref: 3.13
+      - uses: rffontenelle/sphinx-lint-problem-matcher@v1.0.0
+      - run: sphinx-lint
+
+  build-translation:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/setup-python@master
+        with:
+          python-version: 3
+      - uses: actions/checkout@master
+        with:
+          repository: python/cpython
+          ref: 3.13
+      - run: make venv
+        working-directory: ./Doc
+      - uses: actions/checkout@master
+        with:
+          ref: 3.13
+          path: Doc/locales/fa/LC_MESSAGES
+      - run: git pull
+        working-directory: ./Doc/locales/fa/LC_MESSAGES
+      - uses: sphinx-doc/github-problem-matcher@v1.1
+      - run: make -e SPHINXOPTS="--color -D language='fa' -W --keep-going" html
+        working-directory: ./Doc
+      - uses: actions/upload-artifact@master
+        if: success() || failure()
+        with:
+          name: build-3.13-html
+          path: Doc/build/html


### PR DESCRIPTION
Adds lint workflow and build translation workflow borrowed (and simplified) from python-docs-pl

It works like [this](https://github.com/StanFromIreland/python-docs-fa/actions/runs/13247219201) on my fork.

![image](https://github.com/user-attachments/assets/2f30cd1c-ab69-4dda-ba92-0bdae5b3fe0d)

And you are able to download the translated build.

Lint is very hand for catching errors!
